### PR TITLE
Improve test reliability by resetting parameters for test_todo_list_api tests

### DIFF
--- a/tests/test_view_boosters/test_todo_list_api/conftest.py
+++ b/tests/test_view_boosters/test_todo_list_api/conftest.py
@@ -2,12 +2,12 @@ import pytest
 from .todo_list_api.app import db, create_todolist_app, User, Task
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def todolist_app():
     return create_todolist_app(testing=True)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def todolist_with_users_tasks(todolist_app):
     with todolist_app.test_request_context():
         users = [{


### PR DESCRIPTION
This PR aims to improve the reliability of tests `tests/test_view_boosters/test_todo_list_api/test_api_endpoints.py::test_multi_users_creation`, `tests/test_view_boosters/test_todo_list_api/test_api_endpoints.py::test_user_creation` and `tests/test_view_boosters/test_todo_list_api/test_relationship_updates.py::test_list_relationship_new_item` by cleaning the state before running it.

The test can fail on the second run by running it twice. For example, you can run `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_view_boosters/test_todo_list_api/test_api_endpoints.py::test_multi_users_creation` to get the following failure:
```
...
    def do_execute(self, cursor, statement, parameters, context=None):
>       cursor.execute(statement, parameters)
E       sqlite3.IntegrityError: UNIQUE constraint failed: user.email
...
==================== 1 failed, 1 passed, 1 warning in 0.88s ====================
```
More specifically, this PR initializes the parameters for each unit test. In this way, the tests do not fail on the second run any more. It may be better to avoid the state pollutions so that some other tests won't fail in the future due to the shared state pollution.